### PR TITLE
Replace thrussh with russh

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ authors = ["Miyoshi-Ryota <m1yosh1.ry0t4@gmail.com>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thrussh = "0.33.5"
-thrussh-keys = "0.21.0"
+russh = "0.34.0-beta.16"
+russh-keys = "0.22.0-beta.7"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -25,13 +25,7 @@ async fn main() -> Result<(), AsyncSsh2Error> {
     // Key auth is under development. If you need this, then create github issue or contribute this.
     let password = AuthMethod::Password("password".to_string());
 
-    // If you want specify host by ip, then
-    // use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-    // let localhost_v4 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-    // let host = Host::IpAddress(localhost_v4);
-    let host = Host::Hostname("localhost".to_string());
-    let port = 22;
-    let mut client = Client::new(host, port, username, password);
+    let mut client = Client::new("localhost:22", username, password);
     client.connect().await?;
     let result = client.execute("echo test!!!").await?;
     assert_eq!(result.output, "test!!!\n");

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,5 @@
-extern crate thrussh;
-extern crate thrussh_keys;
+extern crate russh;
+extern crate russh_keys;
 use crate::error::AsyncSsh2Error;
 use std::fmt;
 use std::io::Write;
@@ -35,13 +35,13 @@ pub struct Client {
     port: usize,
     username: String,
     auth: AuthMethod,
-    config: Arc<thrussh::client::Config>,
-    channel: Option<thrussh::client::Channel>,
+    config: Arc<russh::client::Config>,
+    channel: Option<russh::Channel<russh::client::Msg>>,
 }
 
 impl Client {
     pub fn new(host: Host, port: usize, username: String, auth: AuthMethod) -> Self {
-        let config = thrussh::client::Config::default();
+        let config = russh::client::Config::default();
         let config = Arc::new(config);
         Self {
             host,
@@ -59,7 +59,13 @@ impl Client {
         let addr = self.host.to_string() + ":" + &self.port.to_string();
         let username = self.username.clone();
         let auth = self.auth.clone();
-        let mut handle = thrussh::client::connect(config, addr, handler).await?;
+        let mut handle = russh::client::connect(
+            config,
+            addr.parse()
+                .map_err(|_| AsyncSsh2Error::AddressWrong(addr))?,
+            handler,
+        )
+        .await?;
         let AuthMethod::Password(password) = auth;
         if handle.authenticate_password(username, password).await? {
             self.channel = Some(handle.channel_open_session().await?);
@@ -78,10 +84,10 @@ impl Client {
             channel.exec(true, command).await?;
             while let Some(msg) = channel.wait().await {
                 match msg {
-                    thrussh::ChannelMsg::Data { ref data } => {
+                    russh::ChannelMsg::Data { ref data } => {
                         command_execute_result_byte.write_all(data).unwrap()
                     }
-                    thrussh::ChannelMsg::ExitStatus { exit_status } => {
+                    russh::ChannelMsg::ExitStatus { exit_status } => {
                         let result = CommandExecutedResult::new(
                             String::from_utf8_lossy(&command_execute_result_byte).to_string(),
                             exit_status,
@@ -121,21 +127,18 @@ impl Handler {
     }
 }
 
-impl thrussh::client::Handler for Handler {
+impl russh::client::Handler for Handler {
     type Error = AsyncSsh2Error;
-    type FutureUnit = std::future::Ready<Result<(Self, thrussh::client::Session), Self::Error>>;
+    type FutureUnit = std::future::Ready<Result<(Self, russh::client::Session), Self::Error>>;
     type FutureBool = std::future::Ready<Result<(Self, bool), Self::Error>>;
 
     fn finished_bool(self, b: bool) -> Self::FutureBool {
         std::future::ready(Ok((self, b)))
     }
-    fn finished(self, session: thrussh::client::Session) -> Self::FutureUnit {
+    fn finished(self, session: russh::client::Session) -> Self::FutureUnit {
         std::future::ready(Ok((self, session)))
     }
-    fn check_server_key(
-        self,
-        _server_public_key: &thrussh_keys::key::PublicKey,
-    ) -> Self::FutureBool {
+    fn check_server_key(self, _server_public_key: &russh_keys::key::PublicKey) -> Self::FutureBool {
         self.finished_bool(true)
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -31,8 +31,7 @@ pub enum AuthMethod {
 }
 
 pub struct Client {
-    host: Host,
-    port: usize,
+    addr: String,
     username: String,
     auth: AuthMethod,
     config: Arc<russh::client::Config>,
@@ -40,12 +39,11 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn new(host: Host, port: usize, username: String, auth: AuthMethod) -> Self {
+    pub fn new(addr: &str, username: String, auth: AuthMethod) -> Self {
         let config = russh::client::Config::default();
         let config = Arc::new(config);
         Self {
-            host,
-            port,
+            addr: addr.into(),
             username,
             auth,
             config,
@@ -56,13 +54,13 @@ impl Client {
     pub async fn connect(&mut self) -> Result<(), AsyncSsh2Error> {
         let handler = Handler::new();
         let config = self.config.clone();
-        let addr = self.host.to_string() + ":" + &self.port.to_string();
+        let addr = &self.addr;
         let username = self.username.clone();
         let auth = self.auth.clone();
         let mut handle = russh::client::connect(
             config,
             addr.parse()
-                .map_err(|_| AsyncSsh2Error::AddressWrong(addr))?,
+                .map_err(|_| AsyncSsh2Error::AddressWrong(addr.into()))?,
             handler,
         )
         .await?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,12 @@
+use russh;
 use thiserror::Error;
-use thrussh;
 
 #[derive(Error, Debug)]
 pub enum AsyncSsh2Error {
     #[error("password is wrong")]
     PasswordWrong,
+    #[error("address '{0}' is wrong")]
+    AddressWrong(String),
     #[error("Other Error Happen")]
-    OtherError(#[from] thrussh::Error),
+    OtherError(#[from] russh::Error),
 }


### PR DESCRIPTION
Because of the poor compatibility of thrussh, use the more compatible russh instead