### PR TITLE
added with_config function to setup the client with config

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,7 @@
 extern crate russh;
 extern crate russh_keys;
 use crate::error::AsyncSsh2Error;
+use russh::client::Config;
 use std::fmt;
 use std::io::Write;
 use std::net::IpAddr;
@@ -40,7 +41,10 @@ pub struct Client {
 
 impl Client {
     pub fn new(addr: &str, username: String, auth: AuthMethod) -> Self {
-        let config = russh::client::Config::default();
+        Self::with_config(addr, username, auth, Config::default())
+    }
+
+    pub fn with_config(addr: &str, username: String, auth: AuthMethod, config: Config) -> Self {
         let config = Arc::new(config);
         Self {
             addr: addr.into(),


### PR DESCRIPTION
Hello, I tried this library on modern SSH configuration this library works great. But for some older IoT devices where `ssh-rsa` is required this library will not work. `russh` in general support all the stuff needed. 

The missing part in `async-ssh2-tokio` the `Client` is created with `russh::client::Config::default()`. I added a method `Client::with_config` 
```rust
use async_ssh2_tokio::client::Client;
...
let ssh_config = russh::client::Config {
    preferred: russh::Preferred {
        key: &[
            russh_keys::key::SSH_RSA,
            russh_keys::key::ED25519,
            //russh_keys::key::RSA_SHA2_256,
            //russh_keys::key::RSA_SHA2_512,
        ],
        ..Default::default()
    },
    ..Default::default()
};
let mut client = Client::with_config(&addr, username, password, ssh_config);
```
Now you can pass in you own config. This is important to support other key algorithms, or timeout settings. This build as opt in and there is no bc.