### PR TITLE
release-0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-ssh2-tokio"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 license-file = "LICENSE"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This library is powered by thrussh.
 ```rust
 [dependencies]
 tokio = "1"
-async-ssh2-tokio = "0.2.1"
+async-ssh2-tokio = "0.3.0"
 ```
 ## Example
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! ```ignore
 //! [dependencies]
 //! tokio = "1"
-//! async-ssh2-tokio = "0.1"
+//! async-ssh2-tokio = "0.3.0"
 //! ```
 //! # Example
 //! ```


### PR DESCRIPTION
Version 0.3.0 is released. This version include following nice pull requests by @avgrocks.

* https://github.com/Miyoshi-Ryota/async-ssh2-tokio/pull/9
* https://github.com/Miyoshi-Ryota/async-ssh2-tokio/pull/10

Thank you for nice contributors!!!
