### PR TITLE
Remove unnecessary mut borrow of Client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -239,7 +239,7 @@ impl Client {
     ///
     /// Can be called multiple times, but every invocation is a new shell context.
     /// Thus `cd`, setting variables and alike have no effect on future invocations.
-    pub async fn execute(&mut self, command: &str) -> Result<CommandExecutedResult, crate::Error> {
+    pub async fn execute(&self, command: &str) -> Result<CommandExecutedResult, crate::Error> {
         let mut receive_buffer = vec![];
         let mut channel = self.connection_handle.channel_open_session().await?;
         channel.exec(true, command).await?;
@@ -271,7 +271,7 @@ impl Client {
         &self.address
     }
 
-    pub async fn disconnect(&mut self) -> Result<(), russh::Error> {
+    pub async fn disconnect(&self) -> Result<(), russh::Error> {
         match self
             .connection_handle
             .disconnect(russh::Disconnect::ByApplication, "", "")


### PR DESCRIPTION
The `Client::execute` (and `Client::disconnect`, although that's probably not as important) method takes `self` as a mutable reference, which prevents running two commands simultaneously. If you try (using the `futures::try_join` macro, for instance):
```rust
async fn test(
    client: &mut async_ssh2_tokio::client::Client,
) -> Result<(), async_ssh2_tokio::Error> {
    futures::try_join!(
        client.execute("time_consuming_command"),
        client.execute("time_consuming_command"),
    )?;

    Ok(())
}
```
the borrow checker understandably complains:
```
error[E0499]: cannot borrow `*client` as mutable more than once at a time
```
However, neither of the two methods actually needs the mut borrow (the relevant russh methods are `channel_open_session` and `disconnect`, and they both take the connection handle as `&self`), and when I just removed it, the example compiled and seemed to work as expected ^^