### PR TITLE
Improve message handling in Client::execute to deal with apparent incompatibility with Ubuntu 18.04.6/openssh7.6p1

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,11 +7,11 @@ use std::io;
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
-    #[error("Key authentification failed")]
+    #[error("Key authentication failed")]
     KeyAuthFailed,
     #[error("Unable to load key, bad format or passphrase")]
     KeyInvalid(russh_keys::Error),
-    #[error("Password authentification failed")]
+    #[error("Password authentication failed")]
     PasswordWrong,
     #[error("Invalid address was provided")]
     AddressInvalid(io::Error),


### PR DESCRIPTION
When using async-ssh2-tokio to talk to Ubuntu 18.04.6 / openssh7.6p1 server, I observe that sometimes the command executes but I get no returned output data. On debugging this, I noted that this seems to due to the ordering of the messages received from the server. Sometimes, for reasons I do not understand, the server delivers the ExitStatus message to the client BEFORE it has delivered the Data (or Extended Data) message. This causes client::execute to wrap up the text it has so far, copy the return code, and return to the caller.

Waiting for Eof message is not a good strategy either because sometimes the Exit-Status messages seems to come after that.

This PR changes that logic so that Data messages update the output string buffer, and Exit Status messages set the exit-status, but that until the channel returns None, because the server closes the channel, we continue to interpret messages.




