### PR TITLE
Increase number of sequential execution in test

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -461,7 +461,7 @@ ASYNC_SSH2_TEST_SERVER_PUB
     async fn sequential_commands() {
         let client = establish_test_host_connection().await;
 
-        for i in 0..30 {
+        for i in 0..1000 {
             std::thread::sleep(time::Duration::from_millis(200));
             let res = client
                 .execute(&format!("echo {i}"))


### PR DESCRIPTION
The following PR should make the sequential commands test more stable in a CI environment, so I increased the number of executions to check the effect. Previously, we observed very rare failures in the CI environment.

PR: https://github.com/Miyoshi-Ryota/async-ssh2-tokio/pull/29