### PR TITLE
Improve stderr handling of Client::execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ async fn main() -> Result<(), async_ssh2_tokio::Error> {
     ).await?;
 
     let result = client.execute("echo Hello SSH").await?;
-    assert_eq!(result.output, "Hello SSH\n");
+    assert_eq!(result.stdout, "Hello SSH\n");
     assert_eq!(result.exit_status, 0);
 
     let result = client.execute("echo Hello Again :)").await?;
-    assert_eq!(result.output, "Hello Again :)\n");
+    assert_eq!(result.stdout, "Hello Again :)\n");
     assert_eq!(result.exit_status, 0);
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,11 @@
 //!     ).await?;
 //!
 //!     let result = client.execute("echo Hello SSH").await?;
-//!     assert_eq!(result.output, "Hello SSH\n");
+//!     assert_eq!(result.stdout, "Hello SSH\n");
 //!     assert_eq!(result.exit_status, 0);
 //!
 //!     let result = client.execute("echo Hello Again :)").await?;
-//!     assert_eq!(result.output, "Hello Again :)\n");
+//!     assert_eq!(result.stdout, "Hello Again :)\n");
 //!     assert_eq!(result.exit_status, 0);
 //!
 //!     Ok(())


### PR DESCRIPTION
As per the SSH specification, stdout is received by extended data messages the same way stdout is received by data messages.
Search for `SSH_EXTENDED_DATA_STDERR` in this document https://datatracker.ietf.org/doc/html/rfc4254
So we are receiving the stderr data over the wire but just not exposing it to the user.

To fix this I believe `CommandExecutedResult` should be extended to include a `stderr` field.
Unfortunately this is a breaking change, since structs can be matched on, so we'll have to release this as v0.7.0 
Since this is a breaking change we may as well rename `output` to `stdout` to make its purpose more clear alongside the `stderr` field.