### PR TITLE
Update dependency russh: 0.37.0-beta.1 -> 0.38.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ authors = ["Miyoshi-Ryota <m1yosh1.ry0t4@gmail.com>"]
 openssl = ["russh/openssl"]
 
 [dependencies]
-russh = "0.37.0-beta.1"
-russh-keys = "0.37.0-beta.1"
+russh = "0.38.0"
+russh-keys = "0.38.0"
 thiserror = "1.0"
 async-trait = "0.1.61"
 


### PR DESCRIPTION
This solves the issue with russh 0.37.x depending on [insecure versions of ed25519-dalek](https://rustsec.org/advisories/RUSTSEC-2022-0093).