### PR TITLE
implement Clone for Client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -99,8 +99,9 @@ impl ServerCheckMethod {
 ///
 ///     Ok(())
 /// }
+#[derive(Clone)]
 pub struct Client {
-    connection_handle: Handle<ClientHandler>,
+    connection_handle: Arc<Handle<ClientHandler>>,
     username: String,
     address: SocketAddr,
 }
@@ -166,7 +167,7 @@ impl Client {
         Self::authenticate(&mut handle, &username, auth).await?;
 
         Ok(Self {
-            connection_handle: handle,
+            connection_handle: Arc::new(handle),
             username,
             address,
         })


### PR DESCRIPTION
Shouldn't client be Clonable? Since we can create multiple copies and run execute independently from each other? from what i can see, russh creates independent channels, and it seems safe to implement Arc over the Handle.

Since this library is high level, It's better to have it Clonable, rather than implementing Arc over all of the async_ssh2_tokio::Client. how do you think?