### PR TITLE
test: add test for #41 and #42

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Cargo.lock
 authorized_keys
 *id_ed25519*
 ssh_host_*_key*
+known_hosts

--- a/src/client.rs
+++ b/src/client.rs
@@ -701,4 +701,16 @@ ASYNC_SSH2_TEST_SERVER_PUB
         .await;
         assert!(client.is_ok());
     }
+
+    #[tokio::test]
+    async fn client_can_be_cloned() {
+        let client = establish_test_host_connection().await;
+        let client2 = client.clone();
+
+        let result1 = client.execute("echo test clone").await.unwrap();
+        let result2 = client2.execute("echo test clone2").await.unwrap();
+
+        assert_eq!(result1.stdout, "test clone\n");
+        assert_eq!(result2.stdout, "test clone2\n");
+    }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -401,6 +401,13 @@ ASYNC_SSH2_TEST_SERVER_PUB
         .unwrap()
     }
 
+    fn test_hostname() -> impl ToSocketAddrsWithHostname {
+        (
+            env("ASYNC_SSH2_TEST_HOST_NAME"),
+            env("ASYNC_SSH2_TEST_HOST_PORT").parse().unwrap(),
+        )
+    }
+
     async fn establish_test_host_connection() -> Client {
         Client::connect(
             (
@@ -666,6 +673,30 @@ ASYNC_SSH2_TEST_SERVER_PUB
             &env("ASYNC_SSH2_TEST_HOST_USER"),
             AuthMethod::with_password(&env("ASYNC_SSH2_TEST_HOST_PW")),
             ServerCheckMethod::with_public_key(key),
+        )
+        .await;
+        assert!(client.is_ok());
+    }
+
+    #[tokio::test]
+    async fn server_check_by_known_hosts_for_ip() {
+        let client = Client::connect(
+            test_address(),
+            &env("ASYNC_SSH2_TEST_HOST_USER"),
+            AuthMethod::with_password(&env("ASYNC_SSH2_TEST_HOST_PW")),
+            ServerCheckMethod::with_known_hosts_file(&env("ASYNC_SSH2_TEST_KNOWN_HOSTS")),
+        )
+        .await;
+        assert!(client.is_ok());
+    }
+
+    #[tokio::test]
+    async fn server_check_by_known_hosts_for_hostname() {
+        let client = Client::connect(
+            test_hostname(),
+            &env("ASYNC_SSH2_TEST_HOST_USER"),
+            AuthMethod::with_password(&env("ASYNC_SSH2_TEST_HOST_PW")),
+            ServerCheckMethod::with_known_hosts_file(&env("ASYNC_SSH2_TEST_KNOWN_HOSTS")),
         )
         .await;
         assert!(client.is_ok());

--- a/tests/async-ssh2-tokio/Dockerfile
+++ b/tests/async-ssh2-tokio/Dockerfile
@@ -8,12 +8,15 @@ ENV ASYNC_SSH2_TEST_CLIENT_PROT_PRIV=/root/.ssh/prot.id_ed25519
 ENV ASYNC_SSH2_TEST_CLIENT_PROT_PASS=test
 ENV ASYNC_SSH2_TEST_SERVER_PUB=/root/server.ed25519.pub
 ENV ASYNC_SSH2_TEST_HOST_PORT=22
+ENV ASYNC_SSH2_TEST_HOST_NAME=ssh-server
+ENV ASYNC_SSH2_TEST_KNOWN_HOSTS=/root/.ssh/known_hosts
 
 COPY tests/async-ssh2-tokio/id_ed25519 /root/.ssh/id_ed25519
 COPY tests/async-ssh2-tokio/id_ed25519.pub /root/.ssh/id_ed25519.pub
 COPY tests/async-ssh2-tokio/prot.id_ed25519 /root/.ssh/prot.id_ed25519
 COPY tests/async-ssh2-tokio/prot.id_ed25519.pub /root/.ssh/prot.id_ed25519.pub
 COPY tests/async-ssh2-tokio/server.ed25519.pub /root/server.ed25519.pub
+COPY tests/async-ssh2-tokio/known_hosts /root/.ssh/known_hosts
 
 WORKDIR /async-ssh2-tokio
 COPY . .

--- a/tests/generate_test_keys.sh
+++ b/tests/generate_test_keys.sh
@@ -22,3 +22,9 @@ rm -f authorized_keys
 cat client.ed25519.pub >> authorized_keys
 cat client.prot.ed25519.pub >> authorized_keys
 mv authorized_keys sshd-test
+
+# setup known_hosts
+export ASYNC_SSH2_TEST_HOST_IP=10.10.10.2
+export ASYNC_SSH2_TEST_HOST_NAME=ssh-server
+awk -v IP=$ASYNC_SSH2_TEST_HOST_IP '{print IP, $1, $2}' server.ed25519.pub > async-ssh2-tokio/known_hosts
+awk -v HOST=$ASYNC_SSH2_TEST_HOST_NAME '{print HOST, $1, $2}' server.ed25519.pub >> async-ssh2-tokio/known_hosts


### PR DESCRIPTION
I have also checked that that the test is failed without #41.
```
test client::tests::server_check_by_known_hosts_for_hostname ... FAILED
```