### PR TITLE
Add method to auth with public key file using ssh-agent

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -21,4 +21,8 @@ pub enum Error {
     ServerCheckFailed,
     #[error("Ssh error occured: {0}")]
     SshError(#[from] russh::Error),
+    #[error("Send error")]
+    SendError(#[from] russh::SendError),
+    #[error("Agent auth error")]
+    AgentAuthError(#[from] russh::AgentAuthError),
 }


### PR DESCRIPTION
# What

This PR:
- Adds the ability to auth by just providing a public key file path which uses ssh-agent to sign the request.

# Why

Some keys - eg. those created by [Secretive](https://github.com/maxgoedjen/secretive) - are stored in the Secure Enclave of MacOS and we cannot export the private key material. Instead, we should use ssh-agent to specify triggering a signing request against it.