### PR TITLE
Add support for keyboard-interactie auth.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,11 +2,15 @@ use std::io;
 
 /// This is the `thiserror` error for all crate errors.
 ///
-/// Most ssh related error are wrapped in the `SshError` variant,
+/// Most ssh related error is wrapped in the `SshError` variant,
 /// giving access to the underlying [`russh::Error`] type.
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
+    #[error("Keyboard-interactive authentication failed")]
+    KeyboardInteractiveAuthFailed,
+    #[error("No keyboard-interactive response for prompt: {0}")]
+    KeyboardInteractiveNoResponseForPrompt(String),
     #[error("Key authentication failed")]
     KeyAuthFailed,
     #[error("Unable to load key, bad format or passphrase: {0}")]

--- a/tests/sshd-test/Dockerfile
+++ b/tests/sshd-test/Dockerfile
@@ -1,18 +1,29 @@
-FROM linuxkit/sshd:62036c2a279715d05e8298b9269a0659964f2619-amd64
+FROM docker.io/ubuntu:24.04
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN apk add openssh-sftp-server=9.1_p1-r5
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/Warsaw
+
+RUN apt-get update && \
+    apt-get install -y openssh-server openssh-sftp-server vim && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # hadolint ignore=DL3006
 RUN echo 'root:root' |chpasswd
 
 RUN sed -ri 's/^#?PermitRootLogin\s+.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
-RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
 RUN sed -ri 's/^#?PasswordAuthentication.*$/PasswordAuthentication yes/g' /etc/ssh/sshd_config
-RUN sed -ri 's/^#Subsystem/Subsystem/g' /etc/ssh/sshd_config
+RUN sed -ri 's/^#?KbdInteractiveAuthentication.*$/KbdInteractiveAuthentication yes/g' /etc/ssh/sshd_config
+
+RUN mkdir /var/run/sshd
 
 COPY ssh_host_ed25519_key ssh_host_ed25519_key.pub /etc/ssh/
 COPY authorized_keys /root/.ssh/authorized_keys
 
 RUN chmod 600 ~/.ssh/authorized_keys
+
+EXPOSE 22
+
+CMD ["/usr/sbin/sshd", "-D", "-e"]


### PR DESCRIPTION
# What

This change adds support for the keyboard-interactive authentication method described in RFC 4256.

# Implementation

This solution introduces the `AuthKeyboardInteractive` builder, which can be converted into an `AuthMethod`.

```rust
let kbi = AuthKeyboardInteractive::new()
    .with_response("Password: ", "abt")
    .with_response("OTP: ", "12345");

let auth = AuthMethod::with_keyboard_interactive(kbi);
...
```

This implementation allows defining responses to known and exact prompts.

 
# Implementation Considerations

Although my solution addresses my problem, it might be too limited for others. Here are some considerations:
 - Should prompts be trimmed of white spaces before comparison?
 - Should prompt comparisons be case-insensitive?
 - Should we add an async handler so API users can implement custom responses (e.g., asking SMS services for OTPs)?
 
If the answer to any of these questions is yes, I am willing to implement those changes.

