### PR TITLE
fix ci error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run unit tests
         shell: bash
         run: ./tests/run_unit_tests.sh

--- a/.github/workflows/super_lint.yml
+++ b/.github/workflows/super_lint.yml
@@ -24,5 +24,6 @@ jobs:
           VALIDATE_RUST_2018: false
           VALIDATE_SHELL_SHFMT: false
           VALIDATE_CHECKOV: false
+          VALIDATE_MARKDOWN_PRETTIER: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ openssl = []
 russh = "0.51.1"
 russh-sftp = "2.0.8"
 thiserror = "2.0"
-async-trait = "0.1"
 tokio = { version = "1", features = ["fs"] }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Docs.rs](https://docs.rs/async-ssh2-tokio/badge.svg)](https://docs.rs/async-ssh2-tokio/latest/async_ssh2_tokio/)
 [![Crates.io](https://img.shields.io/crates/v/async-ssh2-tokio.svg)](https://crates.io/crates/async-ssh2-tokio)
 
-This library is an asynchronous and easy-to-use high level ssh client library
-for rust with the tokio runtime. Powered by the rust ssh implementation
+This library is an asynchronous and easy-to-use high level SSH client library
+for rust with the tokio runtime. Powered by the rust SSH implementation
 [russh](https://github.com/warp-tech/russh).
 
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use russh::client::KeyboardInteractiveAuthResponse;
 use russh::{
     client::{Config, Handle, Handler, Msg},

--- a/tests/sshd-test/Dockerfile
+++ b/tests/sshd-test/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Warsaw
 
 RUN apt-get update && \
-    apt-get install -y openssh-server openssh-sftp-server && \
+    apt-get install -y openssh-server='1:9.6p1-3ubuntu13.4' openssh-sftp-server='1:9.6p1-3ubuntu13.4' && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/tests/sshd-test/Dockerfile
+++ b/tests/sshd-test/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Warsaw
 
 RUN apt-get update && \
-    apt-get install -y openssh-server='1:9.6p1-3ubuntu13.4' openssh-sftp-server='1:9.6p1-3ubuntu13.4' && \
+    apt-get install -y openssh-server='1:9.6p1-3ubuntu13.8' openssh-sftp-server='1:9.6p1-3ubuntu13.8' && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION

* 
* chore: remove unused library. this is not required rust v1.75.0.