### PR TITLE
Fix CI error when install openssh package

### DIFF
--- a/tests/sshd-test/Dockerfile
+++ b/tests/sshd-test/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Warsaw
 
 RUN apt-get update && \
-    apt-get install -y openssh-server='1:9.6p1-3ubuntu13.8' openssh-sftp-server='1:9.6p1-3ubuntu13.8' && \
+    apt-get install -y openssh-server openssh-sftp-server && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fix CI error when install openssh package
```
2025-06-22T07:14:29.6705559Z 2.854 E: Version '1:9.6p1-3ubuntu13.8' for 'openssh-server' was not found
2025-06-22T07:14:29.6706284Z 2.854 E: Version '1:9.6p1-3ubuntu13.8' for 'openssh-sftp-server' was not found
```