### PR TITLE
feat: add comprehensive SSH agent authentication support

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,14 @@ pub enum Error {
     SendError(#[from] russh::SendError),
     #[error("Agent auth error")]
     AgentAuthError(#[from] russh::AgentAuthError),
+    #[error("Failed to connect to SSH agent")]
+    AgentConnectionFailed,
+    #[error("Failed to request identities from SSH agent")]
+    AgentRequestIdentitiesFailed,
+    #[error("SSH agent has no identities")]
+    AgentNoIdentities,
+    #[error("SSH agent authentication failed")]
+    AgentAuthenticationFailed,
     #[error("SFTP error occured: {0}")]
     SftpError(#[from] russh_sftp::client::error::Error),
     #[error("I/O error")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@
 //!     // AuthMethod::with_key_file("key_file_name", None);
 //!     // or
 //!     // AuthMethod::with_key(key: &str, passphrase: Option<&str>)
+//!     // or use SSH agent (Unix/Linux only):
+//!     // AuthMethod::with_agent()
 //!     let auth_method = AuthMethod::with_password("root");
 //!     let mut client = Client::connect(
 //!         ("10.10.10.2", 22),

--- a/tests/run_unit_tests.sh
+++ b/tests/run_unit_tests.sh
@@ -11,7 +11,12 @@ docker compose -f ./tests/docker-compose.yml build --no-cache || exit 1
 
 docker compose -f ./tests/docker-compose.yml up -d || exit 1
 
-docker compose -f ./tests/docker-compose.yml exec -T async-ssh2-tokio cargo test -- --test-threads=2
+# Start ssh-agent in the container and run tests
+docker compose -f ./tests/docker-compose.yml exec -T async-ssh2-tokio bash -c '
+    eval $(ssh-agent -s)
+    ssh-add /root/.ssh/id_ed25519
+    cargo test -- --test-threads=2
+'
 RET=$?
 
 docker compose -f ./tests/docker-compose.yml down


### PR DESCRIPTION
- Add AuthMethod::with_agent() to use SSH agent without key files
- Implement agent authentication logic that tries all available identities
- Add proper error handling for agent-specific failures
- Include comprehensive tests for normal and error cases
- Update Docker test environment to automatically start SSH agent
- Add documentation and examples for the new feature

This allows users to authenticate using SSH agent identities without needing to specify public key files, addressing issue #91.

🤖 Generated with [Claude Code](https://claude.ai/code)