### PR TITLE
Execute a remote command via the ssh connection and perform i/o via channels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ authors = ["Miyoshi-Ryota <m1yosh1.ry0t4@gmail.com>"]
 openssl = []
 
 [dependencies]
-russh = "0.52.1"
+russh = "0.54.6"
 russh-sftp = "2.1.1"
-thiserror = "2.0.12"
+thiserror = "2.0.17"
 tokio = { version = "1.45.1", features = ["fs"] }
 
 [dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 use std::io;
 
+use tokio::sync::mpsc;
+
 /// This is the `thiserror` error for all crate errors.
 ///
 /// Most ssh related error is wrapped in the `SshError` variant,
@@ -41,4 +43,6 @@ pub enum Error {
     SftpError(#[from] russh_sftp::client::error::Error),
     #[error("I/O error")]
     IoError(#[from] io::Error),
+    #[error("Channel send error")]
+    ChannelSendError(#[from] mpsc::error::SendError<Vec<u8>>),
 }


### PR DESCRIPTION
I use this since a while and thougth it would be a good idea to share it.

It adds a function that allow i/o via channels, including using pty for stdin and also runs when the ssh server doesn't send an exit code (which might be the case on industrial devices).

I saw that inbetween a function for doing output via channels was added, but it does not handle stdin. So I think both are usefull.