### PR TITLE
Fixing mobile compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ authors = ["Miyoshi-Ryota <m1yosh1.ry0t4@gmail.com>"]
 openssl = []
 
 [dependencies]
-russh = "0.55.0"
+russh = { version = "0.55.0", default-features = false, features = ["rsa", "flate2", "ring"] }
 log = "0.4"
 russh-sftp = "2.1.1"
 thiserror = "2.0.17"


### PR DESCRIPTION
Since ring works on both mobile and desktop, enabling that feature solves mobile compilation.

You can try it at: https://github.com/ErdemGKSL/remote-explorer

Works both as apk and dev mode. I tried on my phone, i can connect to any server via ssh.