### PR TITLE
fix: support russh-sftp 2.3 API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ openssl = []
 [dependencies]
 russh = { version = "0.55.0", default-features = false, features = ["rsa", "flate2", "ring"] }
 log = "0.4"
-russh-sftp = "2.1.1"
+russh-sftp = "2.1.2"
 thiserror = "2.0.17"
 tokio = { version = "1.45.1", features = ["fs"] }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,7 +3,10 @@ use russh::{
     Channel,
     client::{Config, Handle, Handler, Msg},
 };
-use russh_sftp::{client::SftpSession, protocol::OpenFlags};
+use russh_sftp::{
+    client::{Config as SftpConfig, SftpSession},
+    protocol::OpenFlags,
+};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
@@ -533,7 +536,11 @@ impl Client {
         // start sftp session
         let channel = self.get_channel().await?;
         channel.request_subsystem(true, "sftp").await?;
-        let sftp = SftpSession::new_opts(channel.into_stream(), timeout_seconds).await?;
+        let mut sftp_config = SftpConfig::default();
+        if let Some(timeout_seconds) = timeout_seconds {
+            sftp_config.request_timeout_secs = timeout_seconds;
+        }
+        let sftp = SftpSession::new_with_config(channel.into_stream(), sftp_config).await?;
 
         let file_size = tokio::fs::metadata(&src_file_path).await?.len();
         // read file contents locally


### PR DESCRIPTION
## Summary
- replace the removed `SftpSession::new_opts` call with `SftpSession::new_with_config`
- preserve the existing optional upload timeout by setting `request_timeout_secs` when provided
- fixes fresh builds that resolve `russh-sftp` to 2.3.x from the current `russh-sftp = "2.1.1"` requirement

## Testing
- `cargo +1.95.0 check`
- `cargo +1.95.0 fmt --check` (passes; rustfmt warns that two configured import options are nightly-only)