### PR TITLE
release 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-ssh2-tokio"
-version = "0.12.2"
+version = "0.13.0"
 edition = "2024"
 license-file = "LICENSE"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ for rust with the tokio runtime. Powered by the rust SSH implementation
 ```toml
 [dependencies]
 tokio = "1"
-async-ssh2-tokio = "0.12.2"
+async-ssh2-tokio = "0.13.0"
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

Bump the crate version from `0.12.2` to `0.13.0`.

The release includes the new `Client::connect_via` proxy-jump API and updates to the publicly exposed `russh` dependency line. Under Cargo's pre-1.0 versioning conventions, the dependency/API compatibility change warrants a minor-version bump.

## Validation

- `cargo check --all-targets`